### PR TITLE
will always run syntax check on buffer write.

### DIFF
--- a/plugin/syntastic.vim
+++ b/plugin/syntastic.vim
@@ -95,7 +95,7 @@ highlight link SyntasticWarning SpellCap
 
 augroup syntastic
     autocmd BufReadPost * if g:syntastic_check_on_open | call s:UpdateErrors(1) | endif
-    autocmd BufWritePost * call s:UpdateErrors(1)
+    autocmd BufWritePost * if g:syntastic_check_on_wq | call s:UpdateErrors(1) | endif
 
     autocmd BufWinEnter * call s:BufWinEnterHook()
 


### PR DESCRIPTION
Anyone take a look this please?
Write post event should be ignored if g:syntastic_check_on_wq is not set.

Otherwise, g:syntastic_check_on_wq will not have any effect until exiting from one buffer, which is really annoying.
